### PR TITLE
Changed the consolelink for Cloudfront Distribution

### DIFF
--- a/cloudconsolelink/clouds/aws/links.py
+++ b/cloudconsolelink/clouds/aws/links.py
@@ -118,8 +118,7 @@ def get_links() -> Dict:
             "stackset": None,
         },
         "cloudfront": {  # Amazon CloudFront
-            "distribution": 'https://{data.get("region", "")}.{data.get("console", "")}/cloudfront/v3/\
-                    home?region={data.get("region", "")}#/{data.get("resource", "")}',
+            "distribution": 'https://{data.get("console", "")}/cloudfront/v3/home#/{data.get("resource", "")}',
             "origin-access-identity": None,
             "streaming-distribution": None,
         },


### PR DESCRIPTION
@mpurusottamc Changed the consolelink for Cloudfront Distribution. Removed the region as Cloudfront is a global service and hence doesn't have a specific region and hence is always set to global.
That's the reason previously the region field was coming in empty for the cloudfront distributions. 