### PR TITLE
build issues fixed for pre-release issues

### DIFF
--- a/cloudconsolelink/__init__.py
+++ b/cloudconsolelink/__init__.py
@@ -1,2 +1,2 @@
 # version of the module
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-# Runtime dependencies are currently empty.
+.
+# Install the local checkout for source-based workflows like `uv pip install -r requirements.txt`.
+# setup.py filters this bootstrap entry out of published package metadata.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read_requirements(path: str) -> list[str]:
     lines = []
     for line in read_text(path, required=False).splitlines():
         requirement = line.strip()
-        if requirement and not requirement.startswith("#"):
+        if requirement and not requirement.startswith("#") and requirement not in {".", "-e ."}:
             lines.append(requirement)
     return lines
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -23,3 +23,19 @@ def test_sdist_includes_requirement_files(tmp_path):
     archive_root = archive_path.name.removesuffix(".tar.gz")
     assert f"{archive_root}/requirements.txt" in archive_names
     assert f"{archive_root}/requirements-dev.txt" in archive_names
+
+
+def test_egg_info_excludes_local_bootstrap_requirement(tmp_path):
+    subprocess.run(
+        [sys.executable, "setup.py", "egg_info"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    requires_path = REPO_ROOT / "cloudconsolelink.egg-info" / "requires.txt"
+    requires_text = requires_path.read_text(encoding="utf-8")
+
+    assert "." not in requires_text.splitlines()
+    assert "-e ." not in requires_text


### PR DESCRIPTION
fix issues with build

  × No solution found when resolving dependencies:
  ╰─▶ Because only cloudconsolelink<=3.0.0 is available and you require cloudconsolelink>=3.0.1,<3.1.dev0, we can conclude that your requirements are unsatisfiable.

      hint: `cloudconsolelink` was requested with a pre-release marker (e.g., cloudconsolelink>=3.0.1,<3.1.dev0), but pre-releases weren't enabled (try: `--prerelease=allow`)